### PR TITLE
Update Idea.desktop

### DIFF
--- a/cookbooks/idea/files/default/Idea.desktop
+++ b/cookbooks/idea/files/default/Idea.desktop
@@ -5,6 +5,6 @@ Type=Application
 Terminal=false
 Icon[en_US]=/usr/local/bin/idea-IC-14.1.1/bin/idea.png
 Name[en_US]=Idea
-Exec=/usr/local/bin/idea-IC-14.1.1/bin/idea.sh
+Exec=env JAVA_HOME=/usr/lib/jvm/java-8-oracle-amd64 /usr/local/bin/idea-IC-14.1.1/bin/idea.sh
 Name=Ida
 Icon=/usr/local/bin/idea-IC-14.1.1/bin/idea.png


### PR DESCRIPTION
added JAVA_HOME env variable which worked. However, I believe there is better way to inject the variable into desktop entry. I tried to execute /etc/profile.d/jdk.sh within this file so that we don't have to hard code the jdk version and path, but didn't get this working. Please advice.
